### PR TITLE
Update Commits.php

### DIFF
--- a/lib/GitHub/Receiver/Repositories/Commits.php
+++ b/lib/GitHub/Receiver/Repositories/Commits.php
@@ -26,7 +26,7 @@ class Commits extends AbstractRepositories
      * @return array
      */
     public function listCommits(string $sha = AbstractApi::BRANCH_MASTER, string $path = null, string $author = null,
-                                string $since = null, string $until = null): array
+                                string $since = null, string $until = null, $page = null, $per_page = null): array
     {
         return $this->getApi()->request($this->getApi()->sprintf('/repos/:owner/:repo/commits?:args',
             $this->getRepositories()->getOwner(), $this->getRepositories()->getRepo(), http_build_query([
@@ -34,7 +34,9 @@ class Commits extends AbstractRepositories
                 "path"   => $path,
                 "author" => $author,
                 "since"  => $since,
-                "until"  => $until
+                "until"  => $until,
+				"page"   => $page,
+				"per_page"  => $per_page
             ])));
     }
 


### PR DESCRIPTION
Added capacity to paginate results, by adding the 'page' and 'per_page' parameters as per the API docs.

This can probably be done for other repos as well (ones that allow pagination) but I did it only for commit as am in a rush and that was my need. Should be easy to port to the other places.

Cheers